### PR TITLE
Cease a deprecation warning `CLI_OPTIONS_SCHEMA`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ export default class SwaggerApiPlugin implements Plugin {
         options: {
           message: {
             usage: "Specify the message attached to this deployment",
-            required: false
+            required: false,
+            type: "string"
           }
         }
       }


### PR DESCRIPTION
Currently, when using this plugin, the following deprecation warning appears every time:

    CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
     - SwaggerApiPlugin for "message"
    Please report this issue in plugin issue tracker.
    Starting with next major release, this will be communicated with a thrown error.
    More Info: https://www.serverless.com/framework/docs/deprecations/#CLI_OPTIONS_SCHEMA

The correct URL to be referred seems to be this one:
https://www.serverless.com/framework/docs/deprecations#cli-options-extensions-type-requirement

This PR fixes the deprecation and ceases the warning.

Many thanks.