### PR TITLE
fix(index.ts): Make non-default profiles available for deployment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,14 +100,19 @@ export default class SwaggerApiPlugin implements Plugin {
       return;
     }
 
+    // workaround due to missing `getCredentials` in the type definition
+    const { credentials }  = (aws as any).getCredentials();
+
     const cloudFormation = new AWS.CloudFormation({
       region,
-      apiVersion: "2010-05-15"
+      apiVersion: "2010-05-15",
+      credentials: credentials,
     });
 
     const apigateway = new AWS.APIGateway({
       region,
-      apiVersion: "2015-07-09"
+      apiVersion: "2015-07-09",
+      credentials: credentials,
     });
 
     const stack = await cloudFormation


### PR DESCRIPTION
This PR makes non-default profiles available for deployment by using credentials provided by the provider.

Note that although `getCredentials()` is not found in [type definitions](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/serverless/plugins/aws/provider/awsProvider.d.ts), it is [available](https://github.com/serverless/serverless/blob/1107763df8fb07a40ec45529f77d99e5a0f6d4d6/lib/plugins/aws/provider.js#L1456) in the source code of Serverless.

Closes #43.