### PR TITLE
Fix a hook for API Gateway deployment to work correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export default class SwaggerApiPlugin implements Plugin {
 
     this.hooks = {
       "before:package:finalize": this.updateApiDefinitions(),
-      "after:deploy": () => this.updateApiDeployments(),
+      "after:deploy:deploy": () => this.updateApiDeployments(),
       "updateDeployments:update": () => this.updateApiDeployments()
     };
 


### PR DESCRIPTION
This PR closes #45.

I looked for descriptions on lifecycle events that are recognized by the Serverless Framework, but [they don't seem to be clearly documented](https://www.serverless.com/framework/docs/providers/aws/guide/plugins/). Looking at the [cheat sheet](https://gist.github.com/HyperBrain/50d38027a8f57778d5b0f135d80ea406), I think the API Gateway deployment should be done after `deploy:deploy` and before `deploy:finalize`.

This commit replaces the `after:deploy` hook with `after:deploy:deploy`, which is properly recognized.